### PR TITLE
Introduce keepFirstXmlTag method

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -220,3 +220,42 @@ Set the directory where to save the cache files (see [Cache](usage.md#cache)).
 
 Populate a dependency injection container `$container` with the loaded configuration parameters.
 You can retrieve each parameter with a _dot acces_ key (i.e. database.connection.dsn).
+
+## keepFirstXmlTag
+
+!!! example "Signature"
+`#!php-inline public function keepFirstXmlTag(bool $keep = true): self`
+
+When loading XML files, keep the first xml tag as part of the configuration.
+
+Consider the following xml:
+
+```xml
+<?xml version='1.0' standalone='yes'?>
+<properties>
+  <foo>bar</foo>
+  <bar>baz</bar>
+</properties>
+```
+
+it usually results in the following array:
+
+```php
+<?php
+    [
+        'foo' => 'bar', 
+        'bar' => 'baz'
+    ];
+```
+
+If you call `keepFirstXmTag` then the resulted array is the following:
+
+```php
+<?php
+    [
+        'properties' => [
+            'foo' => 'bar', 
+            'bar' => 'baz'
+        ]
+    ];
+```

--- a/src/ConfigurationBuilder.php
+++ b/src/ConfigurationBuilder.php
@@ -66,6 +66,11 @@ final class ConfigurationBuilder
     private string $cacheDirectory = '';
 
     /**
+     * @var bool if keep the first xml tag in an xml configuration file
+     */
+    private bool $keepFirstXmlTag = false;
+
+    /**
      * Static constructor.
      *
      * @return static
@@ -260,6 +265,20 @@ final class ConfigurationBuilder
     }
 
     /**
+     * Keep also the first tag of a xml configuration.
+     *
+     * @param bool $keep
+     *
+     * @return $this
+     */
+    public function keepFirstXmlTag(bool $keep = true): self
+    {
+        $this->keepFirstXmlTag = $keep;
+
+        return $this;
+    }
+
+    /**
      * Return a populated configuration object.
      *
      * @return object
@@ -332,7 +351,7 @@ final class ConfigurationBuilder
             new JsonFileLoader($fileLocator),
             new NeonFileLoader($fileLocator),
             new PhpFileLoader($fileLocator),
-            new XmlFileLoader($fileLocator),
+            new XmlFileLoader($fileLocator, $this->keepFirstXmlTag),
             new YamlFileLoader($fileLocator)
         ]);
         $delegatingLoader = new DelegatingLoader($loaderResolver);

--- a/src/Loader/XmlFileLoader.php
+++ b/src/Loader/XmlFileLoader.php
@@ -11,6 +11,7 @@ namespace Susina\ConfigBuilder\Loader;
 use Susina\ConfigBuilder\Exception\ConfigurationBuilderException;
 use Susina\ConfigBuilder\Exception\XmlParseBuilderException;
 use Susina\ConfigBuilder\XmlToArrayConverter;
+use Symfony\Component\Config\FileLocatorInterface;
 
 /**
  * XmlFileLoader loads configuration parameters from xml file.
@@ -19,6 +20,14 @@ use Susina\ConfigBuilder\XmlToArrayConverter;
  */
 class XmlFileLoader extends FileLoader
 {
+    private bool $keepFirstTag = false;
+
+    public function __construct(FileLocatorInterface $fileLocator, bool $keepFirstTag = false)
+    {
+        $this->keepFirstTag = $keepFirstTag;
+        parent::__construct($fileLocator);
+    }
+
     /**
      * Loads a Xml file.
      *
@@ -35,7 +44,12 @@ class XmlFileLoader extends FileLoader
     public function load(mixed $resource, ?string $type = null): array
     {
         $converter = new XmlToArrayConverter();
-        $content = $converter->convert(file_get_contents($this->getLocator()->locate($resource)));
+        $xml = file_get_contents($this->getLocator()->locate($resource));
+        if ($this->keepFirstTag) {
+            $xml = "<fake-tag>$xml</fake-tag>";
+        }
+
+        $content = $converter->convert($xml);
 
         return $this->resolveParams($content); //Resolve parameter placeholders (%name%)
     }

--- a/tests/Fixtures/DatabaseConfigurationWithFirstTag.php
+++ b/tests/Fixtures/DatabaseConfigurationWithFirstTag.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+/*
+ * Apache-2 License.
+ * This file is part of susina/config-builder package, release under the APACHE-2 license.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Susina\ConfigBuilder\Tests\Fixtures;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class DatabaseConfigurationWithFirstTag implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('susina');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->arrayNode('database')
+                    ->children()
+                        ->booleanNode('auto_connect')->defaultTrue()->end()
+                        ->scalarNode('default_connection')->defaultValue('default')->end()
+                        ->arrayNode('connections')
+                            ->arrayPrototype()
+                                ->children()
+                                    ->scalarNode('driver')->end()
+                                    ->scalarNode('host')->end()
+                                    ->scalarNode('username')->end()
+                                    ->scalarNode('password')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/tests/Fixtures/database_config.xml
+++ b/tests/Fixtures/database_config.xml
@@ -1,0 +1,18 @@
+<database>
+    <auto_connect>true</auto_connect>
+    <default_connection>mysql</default_connection>
+    <connections>
+        <mysql>
+            <host>localhost</host>
+            <driver>mysql</driver>
+            <username>user</username>
+            <password>pass</password>
+        </mysql>
+        <sqlite>
+            <host>localhost</host>
+            <driver>sqlite</driver>
+            <username>user</username>
+            <password>pass</password>
+        </sqlite>
+    </connections>
+</database>

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -13,6 +13,7 @@ use Susina\ConfigBuilder\Tests\Fixtures\ConfigurationConstructor;
 use Susina\ConfigBuilder\Tests\Fixtures\ConfigurationInit;
 use Susina\ConfigBuilder\Tests\Fixtures\Container;
 use Susina\ConfigBuilder\Tests\Fixtures\DatabaseConfiguration;
+use Susina\ConfigBuilder\Tests\Fixtures\DatabaseConfigurationWithFirstTag;
 
 test('Get configuration', function (array $parameters) {
     $config = ConfigurationBuilder::create()
@@ -217,4 +218,39 @@ test('Populate container', function () {
     ;
 
     expect($container->getParameters())->toBe($expected);
+});
+
+test('Keep first xml tag', function () {
+    $config = ConfigurationBuilder::create()
+        ->addFile('database_config.xml')
+        ->addDirectory(fixtures_dir())
+        ->setConfigurationClass(ConfigurationConstructor::class)
+        ->setDefinition(new DatabaseConfigurationWithFirstTag())
+        ->keepFirstXmlTag()
+        ->getConfigurationArray()
+    ;
+
+    expect($config)->toHaveKey('database')
+        ->and($config)->toBe(
+            [
+                'database' => [
+                    'auto_connect' => true,
+                    'default_connection' => 'mysql',
+                    'connections' => [
+                        'mysql' => [
+                            'host' => 'localhost',
+                            'driver' => 'mysql',
+                            'username' => 'user',
+                            'password' => 'pass'
+                        ],
+                        'sqlite' => [
+                            'host' => 'localhost',
+                            'driver' => 'sqlite',
+                            'username' => 'user',
+                            'password' => 'pass'
+                        ]
+                    ]
+                ]
+            ]
+        );
 });


### PR DESCRIPTION
Introduce `keepFirstXmlTag` method to keep the first tag of an xml file into the configuration.